### PR TITLE
Upgrade dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,13 +72,13 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
-            <version>2.9.0</version>
+            <version>2.11.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.atlassian.oai</groupId>
             <artifactId>swagger-request-validator-core</artifactId>
-            <version>2.0.2</version>
+            <version>2.10.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/io/github/cdimascio/openapi/Validator.kt
+++ b/src/main/kotlin/io/github/cdimascio/openapi/Validator.kt
@@ -26,7 +26,7 @@ internal class Validator<out T>(swaggerJsonPath: String, private val errorHandle
             val status = status(report.messages[0].key)
             val messages = report.messages.map { it.message }
             val error = errorHandler(status, messages)
-            val e = BodyInserters.fromObject(error)
+            val e = BodyInserters.fromValue(error)
             status(status).body(e)
         } else null
     }

--- a/src/test/kotlin/io/github/cdimascio/openapi/ReactiveTest.kt
+++ b/src/test/kotlin/io/github/cdimascio/openapi/ReactiveTest.kt
@@ -135,7 +135,7 @@ class ReactiveTest {
                 .build()
         validate.request(req) {
             ServerResponse.ok().body(
-                    BodyInserters.fromObject(
+                    BodyInserters.fromValue(
                             User(1, "carmine")))
         }
     }


### PR DESCRIPTION
@cdimascio Upgrade swagger request validator to fix a vulnerability issue with commons io library which is a transitive dependency of swagger library. While I am at it, I have also upgraded jackson and removed usage of a deprecated Webflux API




Signed-off-by: Karthik <chejerlakarthik@github.com>