### PR TITLE
Allow to get the body as String

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ validate.request(req).withBody(User::class.java) { body ->
 }
 ```
 
+with body you want to process as string (e.g. for computing a request signature), or that you want to deserialize somehow specifically
+
+```kotlin
+val identity: (String) -> String = { it }
+validate.request(req).withBody(String::class.java, readValue = identity) { body ->
+    ok().body(Mono.just("content length is ${body.length}"))
+}
+```
+
 ### Validate a request (Kotlin + coroutines)
 
 Or you can validate a request in a coroutine style,
@@ -122,6 +131,15 @@ validate.request(req).awaitBody(User::class.java) { body: User ->
     // Now you can do stuff. 
     // For example, lets echo the request as the response 
     ok().bodyValueAndAwait(body)
+}
+```
+
+with body you want to process as string (e.g. for computing a request signature), or that you want to deserialize somehow specifically
+
+```kotlin
+val identity: (String) -> String = { it }
+validate.request(req).awaitBody(String::class.java, identity) { body: String ->
+    ok().bodyValueAndAwait("content length is ${body.length}")
 }
 ```
 
@@ -179,26 +197,36 @@ ArrayList<String> users = new ArrayList<String>() {{
     add("eliana");
 }};
 
-validate.request(null, () -> {
+validate.request(req, () ->
     // Do stuff e.g. return a list of user names
-    ServerResponse.ok().body(fromObject(users));
-});
+    ServerResponse.ok().bodyValue(users)
+);
 ```
 
 with body
 
 ```java
 validate
-    .request(null)
+    .request(req)
     .withBody(User.class, user -> 
         // Note that body is deserialized as User!
         // Now you can do stuff. 
         // For example, lets echo the request as the response
-        return ServerResponse.ok().body(fromObject(user))
+        ServerResponse.ok().bodyValue(user)
     );
 ```
 
-## Example Valiation Output
+with body you want to process as string (e.g. for computing a request signature)
+
+```java
+validate
+    .request(req)
+    .withBody(String.class, s -> s, body ->
+        ServerResponse.ok().bodyValue("content length is " + body.length())
+    );
+```
+
+## Example Validation Output
 
 Let's assume a `POST` request to create a user requires the following request body:
 

--- a/src/main/kotlin/io/github/cdimascio/openapi/Validate.kt
+++ b/src/main/kotlin/io/github/cdimascio/openapi/Validate.kt
@@ -87,12 +87,24 @@ class Validate<out T> internal constructor(
         validator.validateAndAwait(request) ?: handler()
 
     inner class Request(val request: ServerRequest, val objectMapperFactory: ObjectMapperFactory) {
+
         /**
          * Validates a request with body of type [bodyType]. If validation succeeds, the [handler]
          * is called to return a response
          */
         fun <T> withBody(bodyType: Class<T>, handler: (T) -> Mono<ServerResponse>): Mono<ServerResponse> {
-            return BodyValidator(request, bodyType, objectMapperFactory).validate(handler)
+            return withBody(bodyType, readJsonValue(bodyType), handler)
+        }
+
+        /**
+         * Validates a request with body of type [bodyType]. If validation succeeds, the [readValue] function
+         * is used to transform the string body to [bodyType], and the [handler]
+         * is called to return a response
+         */
+        fun <T> withBody(bodyType: Class<T>,
+                         readValue: (String) -> T,
+                         handler: (T) -> Mono<ServerResponse>): Mono<ServerResponse> {
+            return BodyValidator(request, bodyType, objectMapperFactory).validate(handler, readValue)
         }
 
         /**
@@ -102,16 +114,23 @@ class Validate<out T> internal constructor(
          * @return ServerResponse as a result of the call.
          */
         inline fun <reified T> withBody(noinline handler: (T) -> Mono<ServerResponse>): Mono<ServerResponse> =
-            this.withBody(T::class.java, handler)
+            this.withBody(T::class.java, handler = handler)
 
         /**
          * Validates a request with body of type [bodyType] . If validation succeeds, the [handler]
          * is called to return a response.
          * It's a suspended alternative to a [withBody] method.
          */
-        suspend fun <T> awaitBody(bodyType: Class<T>, handler: suspend (T) -> ServerResponse): ServerResponse {
-            return BodyValidator(request, bodyType, objectMapperFactory).validateAndAwait(handler)
+        suspend fun <T> awaitBody(bodyType: Class<T>,
+                                  readValue: (String) -> T = readJsonValue(bodyType),
+                                  handler: suspend (T) -> ServerResponse): ServerResponse {
+            return BodyValidator(request, bodyType, objectMapperFactory).validateAndAwait(handler, readValue)
         }
+
+        private fun <T> readJsonValue(bodyType: Class<T>): (String) -> T = { json ->
+            objectMapperFactory().readValue(json, bodyType)
+        }
+
     }
     /**
      * Creates a new BodyValidator to validate a [request] of type [bodyType] using [objectMapperFactory].
@@ -120,20 +139,19 @@ class Validate<out T> internal constructor(
         /**
          * Validates the body and calls [handler] if the validation succeeds
          */
-        fun validate(handler: (T) -> Mono<ServerResponse>): Mono<ServerResponse> {
-            val success = { json: String -> objectMapperFactory().readValue(json, bodyType) }
+        fun validate(handler: (T) -> Mono<ServerResponse>, readValue: (String) -> T): Mono<ServerResponse> {
             val json = request.body(BodyExtractors.toMono(String::class.java)).switchIfEmpty(Mono.just(""))
-            return json.flatMap { validator.validate(request, it) ?: handler(success(it)) }
+            return json.flatMap { validator.validate(request, it) ?: handler(readValue(it)) }
         }
 
         /**
          * Validates the body and calls [handler] if the validation succeeds.
          * It's a suspended alternative to a [validate] method.
          */
-        suspend fun validateAndAwait(handler: suspend (T) -> ServerResponse): ServerResponse {
-            val success = { json: String -> objectMapperFactory().readValue(json, bodyType) }
+        suspend fun validateAndAwait(handler: suspend (T) -> ServerResponse, readValue: (String) -> T): ServerResponse {
             val json = request.awaitBodyOrNull() ?: ""
-            return json.let { validator.validateAndAwait(request, it) ?: handler(success(it)) }
+            return json.let { validator.validateAndAwait(request, it) ?: handler(readValue(it)) }
         }
+
     }
 }

--- a/src/test/kotlin/io/github/cdimascio/openapi/CoroutinesTest.kt
+++ b/src/test/kotlin/io/github/cdimascio/openapi/CoroutinesTest.kt
@@ -119,6 +119,26 @@ class CoroutinesTest {
     }
 
     @test
+    fun `Validate a post request and provide access to string body`() {
+        val body = """{ "id": 1, "name": "dimascio" }"""
+        val req = MockServerRequest.builder()
+                .method(HttpMethod.POST)
+                .uri(URI.create("/api/users"))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+                .body(Mono.just(body))
+
+        val identity: (String) -> String = { it }
+        val res = runBlocking {
+            validate.request(req).awaitBody(String::class.java, readValue = identity) {
+                assertEquals(body, it)
+                ServerResponse.ok().buildAndAwait()
+            }
+        }
+
+        assertEquals(HttpStatus.OK, res.statusCode())
+    }
+
+    @test
     fun `Validate a get request`() {
         val req = MockServerRequest.builder()
             .method(HttpMethod.GET)

--- a/src/test/kotlin/io/github/cdimascio/openapi/ReactiveTest.kt
+++ b/src/test/kotlin/io/github/cdimascio/openapi/ReactiveTest.kt
@@ -128,6 +128,28 @@ class ReactiveTest {
     }
 
     @test
+    fun `Validate a post request and provide access to string body`() {
+        val body = """{ "id": 1, "name": "dimascio" }"""
+        val req = MockServerRequest.builder()
+                .method(HttpMethod.POST)
+                .uri(URI.create("/api/users"))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON.toString())
+                .body(Mono.just(body))
+
+        val identity: (String) -> String = { it }
+        val res = validate.request(req).withBody(String::class.java, readValue = identity) {
+            assertEquals(body, it)
+            ServerResponse.ok().build()
+        }.block()
+
+        if (res != null) {
+            assertEquals(HttpStatus.OK, res.statusCode())
+        } else {
+            fail("Failed to receive a response")
+        }
+    }
+
+    @test
     fun `Validate a get request`() {
         val req = MockServerRequest.builder()
                 .method(HttpMethod.GET)


### PR DESCRIPTION
We need to calculate a signature of the body (String), which is not possible today because on successful validation the body is deserialized with jackson. Consuming the body additionally is not straight forward, therefore it makes sense that the validator allows to handle the consumed body as String.

To support this case, it's now possible to specify
* `String` as body type and
* an identity function for transforming the read body value

This solution gives some flexibility on how to transform the String
to the desired value passed to the handler - there may be other cases
than just getting the String.

An alternative solution to support this case would be to handle the
get-string-body case very specifically, but then for other cases
other solutions might have to be introduced. Therefore the more
flexible solution is preferred.