### PR TITLE
Add request to ErrorHandler

### DIFF
--- a/src/main/kotlin/io/github/cdimascio/openapi/Validate.kt
+++ b/src/main/kotlin/io/github/cdimascio/openapi/Validate.kt
@@ -15,12 +15,12 @@ operator fun Regex.contains(text: CharSequence): Boolean = this.matches(text)
  * Represents an error when validating a request against the
  * Swagger 2 or OpenApi 3 specification
  */
-data class ValidationError(val code: Int, val message: String)
+data class ValidationError(val request: ServerRequest, val code: Int, val message: String)
 
 /**
  * Handler for validation errors
  */
-typealias ErrorHandler<T> = (status: HttpStatus, List<String>) -> T
+typealias ErrorHandler<T> = (request: ServerRequest, status: HttpStatus, List<String>) -> T
 
 /**
  * Factory for ObjectMapper.
@@ -40,7 +40,7 @@ class Validate<out T> internal constructor(
      */
     companion object Instance {
         private val defaultErrorHandler: ErrorHandler<ValidationError> =
-            { status, messages -> ValidationError(status.value(), messages[0]) }
+            { request, status, messages -> ValidationError(request, status.value(), messages[0]) }
 
         private val defaultObjectMapperFactory: ObjectMapperFactory = { jacksonObjectMapper() }
 

--- a/src/main/kotlin/io/github/cdimascio/openapi/Validator.kt
+++ b/src/main/kotlin/io/github/cdimascio/openapi/Validator.kt
@@ -10,7 +10,7 @@ import org.springframework.web.reactive.function.server.ServerResponse.status
 import org.springframework.web.reactive.function.server.bodyValueAndAwait
 import reactor.core.publisher.Mono
 
-internal class Validator<out T>(swaggerJsonPath: String, private val errorHandler: (status: HttpStatus, List<String>) -> T) {
+internal class Validator<out T>(swaggerJsonPath: String, private val errorHandler: ErrorHandler<T>) {
     private operator fun Regex.contains(text: CharSequence) = this.matches(text)
     private val swaggerValidator = OpenApiInteractionValidator
         .createFor(swaggerJsonPath)
@@ -25,7 +25,7 @@ internal class Validator<out T>(swaggerJsonPath: String, private val errorHandle
         return if (report.hasErrors()) {
             val status = status(report.messages[0].key)
             val messages = report.messages.map { it.message }
-            val error = errorHandler(status, messages)
+            val error = errorHandler(request, status, messages)
             val e = BodyInserters.fromValue(error)
             status(status).body(e)
         } else null
@@ -40,7 +40,7 @@ internal class Validator<out T>(swaggerJsonPath: String, private val errorHandle
         return if (report.hasErrors()) {
             val status = status(report.messages[0].key)
             val messages = report.messages.map { it.message }
-            val error = errorHandler(status, messages)
+            val error = errorHandler(request, status, messages)
             status(status).bodyValueAndAwait(error as Any)
         } else null
     }

--- a/src/test/kotlin/io/github/cdimascio/openapi/CoroutinesTest.kt
+++ b/src/test/kotlin/io/github/cdimascio/openapi/CoroutinesTest.kt
@@ -17,8 +17,8 @@ import java.net.URI
 import org.junit.jupiter.api.Test as test
 
 class CoroutinesTest {
-    private val validate = Validate.configure("api.yaml") { status, message ->
-        MyError(status.value(), message[0])
+    private val validate = Validate.configure("api.yaml") { request, status, message ->
+        MyError(request, status.value(), message[0])
     }
 
     @test

--- a/src/test/kotlin/io/github/cdimascio/openapi/MyError.kt
+++ b/src/test/kotlin/io/github/cdimascio/openapi/MyError.kt
@@ -1,3 +1,5 @@
 package io.github.cdimascio.openapi
 
-data class MyError(val code: Int, val name: String)
+import org.springframework.web.reactive.function.server.ServerRequest
+
+data class MyError(val request: ServerRequest, val code: Int, val name: String)

--- a/src/test/kotlin/io/github/cdimascio/openapi/ReactiveTest.kt
+++ b/src/test/kotlin/io/github/cdimascio/openapi/ReactiveTest.kt
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test as test
 
 
 class ReactiveTest {
-    private val validate = Validate.configure("api.yaml") { status, message ->
-        MyError(status.value(), message[0])
+    private val validate = Validate.configure("api.yaml") { request, status, message ->
+        MyError(request, status.value(), message[0])
     }
 
     @test


### PR DESCRIPTION
So that the error handler can use information of the request for
handling the error, e.g. to log the request uri or some headers.

Note that this is a binary incompatible change (consider to bump the
major version)! Reasoning: Trying to achieve this change in a binary
compatible manner is considered to be adding too much (unnecessary)
code, compared to how easy it is for library users to handle this change.
Additionally, only users with a custom error handler would be affected.